### PR TITLE
Standardize Drupal version to 11 with 11.x-dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     working_dir: /src
     command: bash -c "./scripts/run-drupal-lint.sh"
     environment:
-      TARGET_DRUPAL_CORE_VERSION: 10
+      TARGET_DRUPAL_CORE_VERSION: 11
     volumes:
       - .:/src
 
@@ -16,7 +16,7 @@ services:
     working_dir: /src
     command: bash -c "./scripts/run-drupal-lint-auto-fix.sh"
     environment:
-      TARGET_DRUPAL_CORE_VERSION: 10
+      TARGET_DRUPAL_CORE_VERSION: 11
     volumes:
       - .:/src
 
@@ -27,6 +27,6 @@ services:
    command: bash -c "/src/scripts/run-drupal-check.sh"
    tty: true
    environment:
-     DRUPAL_RECOMMENDED_PROJECT: 10.3.x-dev
+     DRUPAL_RECOMMENDED_PROJECT: 11.x-dev
    volumes:
       - .:/src 


### PR DESCRIPTION
## Summary
- Updates docker-compose.yml to use Drupal 11 instead of Drupal 10
- Changes DRUPAL_RECOMMENDED_PROJECT from 10.3.x-dev to 11.x-dev  
- Ensures consistency across all analyze group projects

## Test plan
- [ ] Verify drupal-lint works with Drupal 11
- [ ] Confirm drupal-check works with 11.x-dev

🤖 Generated with [Claude Code](https://claude.ai/code)