### PR TITLE
Improve Views UX: add language filter and standardize submit button

### DIFF
--- a/analyze_ai_brand_voice.info.yml
+++ b/analyze_ai_brand_voice.info.yml
@@ -5,6 +5,6 @@ package: Analyze
 core_version_requirement: ^10.2 || ^11
 configure: analyze_ai_brand_voice.settings
 dependencies:
-  - analyze:analyze
+  - analyze:analyze (>=1.1.0)
   - ai:ai
   - views_color_scales:views_color_scales

--- a/analyze_ai_brand_voice.install
+++ b/analyze_ai_brand_voice.install
@@ -145,3 +145,80 @@ function analyze_ai_brand_voice_update_8001() {
 
   return t('No brand voice analyzer settings found to update.');
 }
+
+/**
+ * Update view: language filter and submit button.
+ */
+function analyze_ai_brand_voice_update_8002() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('views.view.ai_brand_voice_analysis');
+
+  if ($config->isNew()) {
+    return t('View not found.');
+  }
+
+  $filters = $config->get('display.default.display_options.filters') ?? [];
+
+  // Remove old langcode filter if present.
+  unset($filters['langcode']);
+
+  // Add language filter using node relationship.
+  $langcode_filter = [
+    'id' => 'langcode',
+    'table' => 'node_field_data',
+    'field' => 'langcode',
+    'relationship' => 'entity_id',
+    'group_type' => 'group',
+    'admin_label' => '',
+    'entity_type' => 'node',
+    'entity_field' => 'langcode',
+    'plugin_id' => 'language',
+    'operator' => 'in',
+    'value' => [
+      '***LANGUAGE_site_default***' => '***LANGUAGE_site_default***',
+    ],
+    'group' => 1,
+    'exposed' => TRUE,
+    'expose' => [
+      'operator_id' => 'langcode_op',
+      'label' => 'Translation language',
+      'description' => '',
+      'use_operator' => FALSE,
+      'operator' => 'langcode_op',
+      'operator_limit_selection' => FALSE,
+      'operator_list' => [],
+      'identifier' => 'langcode',
+      'required' => FALSE,
+      'remember' => FALSE,
+      'multiple' => FALSE,
+      'remember_roles' => [
+        'authenticated' => 'authenticated',
+      ],
+      'reduce' => FALSE,
+    ],
+    'is_grouped' => FALSE,
+    'group_info' => [
+      'label' => '',
+      'description' => '',
+      'identifier' => '',
+      'optional' => TRUE,
+      'widget' => 'select',
+      'multiple' => FALSE,
+      'remember' => FALSE,
+      'default_group' => 'All',
+      'default_group_multiple' => [],
+      'group_items' => [],
+    ],
+  ];
+
+  // Add langcode filter at the beginning.
+  $filters = ['langcode' => $langcode_filter] + $filters;
+  $config->set('display.default.display_options.filters', $filters);
+
+  // Standardize submit button.
+  $config->set('display.default.display_options.exposed_form.options.submit_button', 'Apply filters');
+
+  $config->save();
+
+  return t('Updated view filters and submit button.');
+}

--- a/analyze_ai_brand_voice.views.inc
+++ b/analyze_ai_brand_voice.views.inc
@@ -71,10 +71,10 @@ function analyze_ai_brand_voice_views_data() {
   $data['analyze_ai_brand_voice_results']['langcode'] = [
     'title' => t('Language'),
     'help' => t('The language of the analyzed content.'),
-    'field' => ['id' => 'standard'],
-    'filter' => ['id' => 'string'],
+    'field' => ['id' => 'language'],
+    'filter' => ['id' => 'language'],
     'sort' => ['id' => 'standard'],
-    'argument' => ['id' => 'string'],
+    'argument' => ['id' => 'language'],
   ];
 
   // Brand voice score field.

--- a/config/install/views.view.ai_brand_voice_analysis.yml
+++ b/config/install/views.view.ai_brand_voice_analysis.yml
@@ -383,7 +383,7 @@ display:
       exposed_form:
         type: basic
         options:
-          submit_button: Apply
+          submit_button: 'Apply filters'
           reset_button: false
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
@@ -417,6 +417,48 @@ display:
           granularity: second
       arguments: {  }
       filters:
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: entity_id
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_site_default***': '***LANGUAGE_site_default***'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: 'Translation language'
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         score:
           id: score
           table: analyze_ai_brand_voice_results


### PR DESCRIPTION
## Summary
- Add exposed language filter using node relationship, defaulting to site's default language
- Change submit button text to "Apply filters" for consistency across analyze modules
- Consolidate update hooks into single `hook_update_8002`

## Test plan
- [ ] Run `drush updb` to apply update hook
- [ ] Run `drush cr` to rebuild caches
- [ ] Verify language filter appears and defaults to site's default language
- [ ] Verify submit button shows "Apply filters"

Closes #9