### PR TITLE
Improve Views UX part 2: time_diff, fields, and display enhancements

### DIFF
--- a/analyze_ai_brand_voice.install
+++ b/analyze_ai_brand_voice.install
@@ -447,7 +447,8 @@ function analyze_ai_brand_voice_update_8003() {
     $changes[] = 'analyzed_timestamp field';
   }
   else {
-    // Set time ago format on analyzed_timestamp (Views Date plugin uses date_format option).
+    // Set time ago format on analyzed_timestamp.
+    // Views Date plugin uses date_format option.
     $fields['analyzed_timestamp']['date_format'] = 'time ago';
     $fields['analyzed_timestamp']['custom_date_format'] = '';
     $fields['analyzed_timestamp']['timezone'] = '';
@@ -459,7 +460,5 @@ function analyze_ai_brand_voice_update_8003() {
   $config->set('display.default.display_options.style.options.info', $info);
   $config->save();
 
-  return empty($changes)
-    ? t('No updates needed.')
-    : t('Updated: @changes.', ['@changes' => implode(', ', $changes)]);
+  return t('Updated: @changes.', ['@changes' => implode(', ', $changes)]);
 }

--- a/analyze_ai_brand_voice.install
+++ b/analyze_ai_brand_voice.install
@@ -222,3 +222,244 @@ function analyze_ai_brand_voice_update_8002() {
 
   return t('Updated view filters and submit button.');
 }
+
+/**
+ * Add view fields, filters, enable time_diff, and standardize display.
+ */
+function analyze_ai_brand_voice_update_8003() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('views.view.ai_brand_voice_analysis');
+
+  if ($config->isNew()) {
+    return t('View not found.');
+  }
+
+  $changes = [];
+
+  // Add content type filter if not present.
+  $filters = $config->get('display.default.display_options.filters') ?? [];
+  if (!isset($filters['type'])) {
+    $type_filter = [
+      'id' => 'type',
+      'table' => 'node_field_data',
+      'field' => 'type',
+      'relationship' => 'entity_id',
+      'group_type' => 'group',
+      'admin_label' => '',
+      'entity_type' => 'node',
+      'entity_field' => 'type',
+      'plugin_id' => 'bundle',
+      'operator' => 'in',
+      'value' => [],
+      'group' => 1,
+      'exposed' => TRUE,
+      'expose' => [
+        'operator_id' => 'type_op',
+        'label' => 'Content type',
+        'description' => '',
+        'use_operator' => FALSE,
+        'operator' => 'type_op',
+        'operator_limit_selection' => FALSE,
+        'operator_list' => [],
+        'identifier' => 'type',
+        'required' => FALSE,
+        'remember' => FALSE,
+        'multiple' => FALSE,
+        'remember_roles' => ['authenticated' => 'authenticated'],
+        'reduce' => FALSE,
+      ],
+      'is_grouped' => FALSE,
+      'group_info' => [
+        'label' => '',
+        'description' => '',
+        'identifier' => '',
+        'optional' => TRUE,
+        'widget' => 'select',
+        'multiple' => FALSE,
+        'remember' => FALSE,
+        'default_group' => 'All',
+        'default_group_multiple' => [],
+        'group_items' => [],
+      ],
+    ];
+    $filters = ['type' => $type_filter] + $filters;
+    $config->set('display.default.display_options.filters', $filters);
+    $changes[] = 'content type filter';
+  }
+
+  // Define field templates.
+  $alter_defaults = [
+    'alter_text' => FALSE,
+    'text' => '',
+    'make_link' => FALSE,
+    'path' => '',
+    'absolute' => FALSE,
+    'external' => FALSE,
+    'replace_spaces' => FALSE,
+    'path_case' => 'none',
+    'trim_whitespace' => FALSE,
+    'alt' => '',
+    'rel' => '',
+    'link_class' => '',
+    'prefix' => '',
+    'suffix' => '',
+    'target' => '',
+    'nl2br' => FALSE,
+    'max_length' => 0,
+    'word_boundary' => TRUE,
+    'ellipsis' => TRUE,
+    'more_link' => FALSE,
+    'more_link_text' => '',
+    'more_link_path' => '',
+    'strip_tags' => FALSE,
+    'trim' => FALSE,
+    'preserve_tags' => '',
+    'html' => FALSE,
+  ];
+
+  $time_diff_settings = [
+    'date_format' => 'medium',
+    'custom_date_format' => '',
+    'timezone' => '',
+    'tooltip' => ['date_format' => 'long', 'custom_date_format' => ''],
+    'time_diff' => [
+      'enabled' => TRUE,
+      'future_format' => '@interval hence',
+      'past_format' => '@interval ago',
+      'granularity' => 1,
+      'refresh' => 60,
+    ],
+  ];
+
+  $fields = $config->get('display.default.display_options.fields') ?? [];
+  $columns = $config->get('display.default.display_options.style.options.columns') ?? [];
+  $info = $config->get('display.default.display_options.style.options.info') ?? [];
+
+  // Add created field if not present.
+  if (!isset($fields['created'])) {
+    $fields['created'] = [
+      'id' => 'created',
+      'table' => 'node_field_data',
+      'field' => 'created',
+      'relationship' => 'entity_id',
+      'group_type' => 'group',
+      'admin_label' => '',
+      'entity_type' => 'node',
+      'entity_field' => 'created',
+      'plugin_id' => 'field',
+      'label' => 'Created',
+      'exclude' => FALSE,
+      'alter' => $alter_defaults,
+      'element_type' => '',
+      'element_class' => '',
+      'element_label_type' => '',
+      'element_label_class' => '',
+      'element_label_colon' => TRUE,
+      'element_wrapper_type' => '',
+      'element_wrapper_class' => '',
+      'element_default_classes' => TRUE,
+      'empty' => '',
+      'hide_empty' => FALSE,
+      'empty_zero' => FALSE,
+      'hide_alter_empty' => TRUE,
+      'click_sort_column' => 'value',
+      'type' => 'timestamp',
+      'settings' => $time_diff_settings,
+      'group_column' => 'value',
+      'group_columns' => [],
+      'group_rows' => TRUE,
+      'delta_limit' => 0,
+      'delta_offset' => 0,
+      'delta_reversed' => FALSE,
+      'delta_first_last' => FALSE,
+      'multi_type' => 'separator',
+      'separator' => ', ',
+      'field_api_classes' => FALSE,
+    ];
+    $columns['created'] = 'created';
+    $info['created'] = [
+      'sortable' => TRUE,
+      'default_sort_order' => 'desc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => FALSE,
+      'responsive' => '',
+    ];
+    $changes[] = 'created field';
+  }
+
+  // Enable time_diff on changed field if present.
+  if (isset($fields['changed'])) {
+    $fields['changed']['settings'] = $time_diff_settings;
+    $fields['changed']['label'] = 'Last edited';
+    $changes[] = 'time_diff on changed field';
+  }
+
+  // Add analyzed_timestamp field if not present.
+  if (!isset($fields['analyzed_timestamp'])) {
+    $fields['analyzed_timestamp'] = [
+      'id' => 'analyzed_timestamp',
+      'table' => 'analyze_ai_brand_voice_results',
+      'field' => 'analyzed_timestamp',
+      'relationship' => 'none',
+      'group_type' => 'group',
+      'admin_label' => '',
+      'plugin_id' => 'date',
+      'label' => 'Last analyzed',
+      'exclude' => FALSE,
+      'date_format' => 'time ago',
+      'custom_date_format' => '',
+      'timezone' => '',
+      'alter' => $alter_defaults,
+      'element_type' => '',
+      'element_class' => '',
+      'element_label_type' => '',
+      'element_label_class' => '',
+      'element_label_colon' => TRUE,
+      'element_wrapper_type' => '',
+      'element_wrapper_class' => '',
+      'element_default_classes' => TRUE,
+      'empty' => '',
+      'hide_empty' => FALSE,
+      'empty_zero' => FALSE,
+      'hide_alter_empty' => TRUE,
+      'click_sort_column' => 'value',
+      'group_column' => 'value',
+      'group_columns' => [],
+      'group_rows' => TRUE,
+      'delta_limit' => 0,
+      'delta_offset' => 0,
+      'delta_reversed' => FALSE,
+      'delta_first_last' => FALSE,
+      'multi_type' => 'separator',
+      'separator' => ', ',
+      'field_api_classes' => FALSE,
+    ];
+    $columns['analyzed_timestamp'] = 'analyzed_timestamp';
+    $info['analyzed_timestamp'] = [
+      'sortable' => TRUE,
+      'default_sort_order' => 'desc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => FALSE,
+      'responsive' => '',
+    ];
+    $changes[] = 'analyzed_timestamp field';
+  }
+  else {
+    // Set time ago format on analyzed_timestamp (Views Date plugin uses date_format option).
+    $fields['analyzed_timestamp']['date_format'] = 'time ago';
+    $fields['analyzed_timestamp']['custom_date_format'] = '';
+    $fields['analyzed_timestamp']['timezone'] = '';
+    $changes[] = 'time ago format on analyzed_timestamp';
+  }
+
+  $config->set('display.default.display_options.fields', $fields);
+  $config->set('display.default.display_options.style.options.columns', $columns);
+  $config->set('display.default.display_options.style.options.info', $info);
+  $config->save();
+
+  return empty($changes)
+    ? t('No updates needed.')
+    : t('Updated: @changes.', ['@changes' => implode(', ', $changes)]);
+}

--- a/config/install/views.view.ai_brand_voice_analysis.yml
+++ b/config/install/views.view.ai_brand_voice_analysis.yml
@@ -7,6 +7,7 @@ dependencies:
   module:
     - analyze_ai_brand_voice
     - node
+    - user
     - views_color_scales
 _core:
   default_config_hash: bVy7x3jl52OXDPnEl8BtShtyjzWsjtaIF00Pd-1pAtI
@@ -154,6 +155,83 @@ display:
           color_scale_auto: 1
           color_scale_min_color: '#FFB3B3'
           color_scale_max_color: '#B3FFB3'
+        analyzed_timestamp:
+          id: analyzed_timestamp
+          table: analyze_ai_brand_voice_results
+          field: analyzed_timestamp
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: date
+          label: 'Last analyzed'
+          exclude: false
+          date_format: 'time ago'
+          custom_date_format: ''
+          timezone: ''
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: true
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 1
+              refresh: 60
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         type:
           id: type
           table: node_field_data
@@ -280,12 +358,88 @@ display:
               date_format: long
               custom_date_format: ''
             time_diff:
-              enabled: false
+              enabled: true
               future_format: '@interval hence'
               past_format: '@interval ago'
-              granularity: 2
+              granularity: 1
               refresh: 60
               description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: entity_id
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: field
+          label: Created
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: true
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 1
+              refresh: 60
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -366,7 +520,7 @@ display:
         options:
           offset: 0
           pagination_heading_level: h4
-          items_per_page: 96
+          items_per_page: 100
           total_pages: null
           id: 0
           tags:
@@ -399,15 +553,15 @@ display:
         options: {  }
       empty: {  }
       sorts:
-        created:
-          id: created
+        changed:
+          id: changed
           table: node_field_data
-          field: created
-          relationship: none
+          field: changed
+          relationship: entity_id
           group_type: group
           admin_label: ''
           entity_type: node
-          entity_field: created
+          entity_field: changed
           plugin_id: date
           order: DESC
           expose:
@@ -417,6 +571,47 @@ display:
           granularity: second
       arguments: {  }
       filters:
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: entity_id
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: 'Content type'
+            description: ''
+            use_operator: false
+            operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         langcode:
           id: langcode
           table: node_field_data
@@ -488,25 +683,6 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
-              marketer: '0'
-              administrator: '0'
-              dxpr_enterprise: '0'
-              marketing: '0'
-              sooperthemes_enterprise: '0'
-              stoppedsubscription: '0'
-              t1_support: '0'
-              t2_support: '0'
-              business: '0'
-              dxpr_business: '0'
-              dxpr_personal: '0'
-              dxpr_professional: '0'
-              growth: '0'
-              legacy_agency_membership: '0'
-              pre-sooperthemes_membership: '0'
-              sooperthemes_professional: '0'
-              sooperthemes_single: '0'
-              standard: '0'
             min_placeholder: ''
             max_placeholder: ''
             placeholder: ''
@@ -528,7 +704,7 @@ display:
           field: title
           relationship: entity_id
           group_type: group
-          admin_label: Search
+          admin_label: ''
           entity_type: node
           entity_field: title
           plugin_id: string
@@ -550,25 +726,6 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
-              marketer: '0'
-              administrator: '0'
-              dxpr_enterprise: '0'
-              marketing: '0'
-              sooperthemes_enterprise: '0'
-              stoppedsubscription: '0'
-              t1_support: '0'
-              t2_support: '0'
-              business: '0'
-              dxpr_business: '0'
-              dxpr_personal: '0'
-              dxpr_professional: '0'
-              growth: '0'
-              legacy_agency_membership: '0'
-              pre-sooperthemes_membership: '0'
-              sooperthemes_professional: '0'
-              sooperthemes_single: '0'
-              standard: '0'
             placeholder: ''
           is_grouped: false
           group_info:
@@ -591,10 +748,12 @@ display:
           columns:
             title: title
             score: score
+            analyzed_timestamp: analyzed_timestamp
             type: type
+            created: created
             changed: changed
             uid: uid
-          default: '-1'
+          default: analyzed_timestamp
           info:
             title:
               sortable: true
@@ -610,9 +769,23 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
+            analyzed_timestamp:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
             type:
               sortable: true
               default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: desc
               align: ''
               separator: ''
               empty_column: false
@@ -667,10 +840,11 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user.permissions
       tags: {  }
   page_1:
     id: page_1
-    display_title: Page
+    display_title: 'All Brand Voice Results'
     display_plugin: page
     position: 1
     display_options:
@@ -691,4 +865,5 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - user.permissions
       tags: {  }


### PR DESCRIPTION
## Summary

Follow-up to #10 (Improve Views UX). This PR adds additional view enhancements:

- Add `hook_update_8003` for view improvements
- Add `analyzed_timestamp` field with "time ago" format
- Add `created` field with time_diff enabled
- Enable time_diff on `changed` field (shows relative time like "2 days ago")
- Add content type exposed filter
- Change default sort from `created` to `changed`
- Standardize field ordering: title → score → analyzed_timestamp → type → changed → created → uid
- Add `user` module dependency and `user.permissions` cache context
- Change pager from 96 to 100 items
- Clean up remember_roles to only `authenticated`

## Test plan

- [ ] Run `drush updb` to apply update hook 8003
- [ ] Run `drush cr` to rebuild caches
- [ ] Verify "Last analyzed" shows relative time (e.g., "2 weeks ago")
- [ ] Verify "Last edited" and "Created" show relative time with tooltip
- [ ] Verify content type filter appears
- [ ] Verify field order matches: Title, Score, Last analyzed, Content type, Last edited, Created, Authored by